### PR TITLE
Updated to new website schema

### DIFF
--- a/archiver.py
+++ b/archiver.py
@@ -76,7 +76,7 @@ def archive(story_id, force_update = False, full_update = False, threads_per_bat
         temp_old_archive = info.to_dict()
         old_archive['info'].update(temp_old_archive)
         #Hack for missing field, maybe dlete in the future
-        if 'last_full_update' not in old_archive['info']:
+        if old_archive['info'].get('last_full_update') is None:
             old_archive['info']['last_full_update'] = 0
 
         #full update check

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,13 @@
+-i https://pypi.org/simple
+
 beautifulsoup4==4.8.2
 certifi==2019.11.28
 chardet==3.0.4
 idna==2.8
 lxml==4.4.2
-MechanicalSoup==0.12.0
+mechanicalsoup==0.12.0
+python-dateutil==2.8.2
+pyyaml==6.0
 requests==2.22.0
 six==1.13.0
 soupsieve==1.9.5

--- a/run.py
+++ b/run.py
@@ -5,8 +5,8 @@ import argparse
 import json
 import os
 
-def update(args):
-    update_archive()
+# def update(args):
+#     update_archive()
 
 def get(args):
     for id in args.ids:
@@ -23,13 +23,15 @@ def update(args):
         if ('story.json' in files):
             archive_info = json.loads(open(root + "/story.json").read())
             if 'deleted' not in archive_info['info']:
-                archive(str(archive_info['info']['id']))
+                archive(str(archive_info['info']['id']), force_update=args.force, full_update=args.full)
 
 parser = argparse.ArgumentParser(description='Scrapes Writing.com')
 subparsers = parser.add_subparsers()
 
 update_help = 'updates all existing archives.'
 parser_update = subparsers.add_parser('update', help=update_help)
+parser_update.add_argument('--force', action='store_true', help='Force update even if no new chapters')
+parser_update.add_argument('--full', action='store_true', help='Perform full refresh')
 parser_update.set_defaults(func=update)
 
 get_help = 'download/update the specified list of item_ids.'
@@ -43,4 +45,7 @@ parser_search.add_argument('urls',nargs='+',help=get_search_help)
 parser_search.set_defaults(func=get_search)
 
 args = parser.parse_args()
-args.func(args)
+if hasattr(args, "func"):
+    args.func(args)
+else:
+    print("Please specify an action of: {update, get, get_search}")

--- a/scraper.py
+++ b/scraper.py
@@ -20,14 +20,14 @@ from session import browser
 #   Really important note here. If the chapter's descent is '1' or '0' (it is the first chapter), you must format these chapter xpaths with '1'. else, format them with '0'.
 #   This is because the first chapter doesn't have the additional div element before all content announcing which choice you just took.
 
-chapter_title_xp                = "//span[starts-with(@title, 'Created')]/h2/text()"
-chapter_content_xp              = "//div[@style='padding:25px 6px 20px 11px;min-width:482px;']/div"
+chapter_title_xp                = "//h2[starts-with(@title, 'Created')]/text()"
+chapter_content_xp              = "//div[contains(@style,'min-width:482px;')]/div"
 chapter_author_name_xp          = "(//a[starts-with(@title, 'Username:')])[2]/text()"
 chapter_author_name_xp_2        = '//i[starts-with(text(), "by")]/text()' #deleted authors?
 chapter_author_link_xp          = '(//a[@class="imgLink imgPortLink"])[2]/@href' 
-chapter_choices_xp              = "//div[@id='end_choices']/parent::*//a"
+chapter_choices_xp              = '//*[starts-with(@id,"choices_")]//a'
 chapter_id_xp                   = '//*[text()="ID #"]/b/text()' #https://www.writing.com/main/interact/cid/#### it's a link on member accounts
-chapter_created_date_xp         = "//span[starts-with(@title, 'Created')]/@title"
+chapter_created_date_xp         = "//*[@id='showDetailsArea']/div/div[1]/div[3]"
 
 #For a story page
 story_title_xp              =   "//a[contains(@class, 'proll')]/text()"
@@ -91,6 +91,10 @@ def parse_date(date):
 
     timedate = timedate.replace(tzinfo=tz.gettz('America/New_York'))
     return int(timedate.timestamp())
+
+def parse_date_element(ele):
+    # new format where the 'am/pm' designation is in a sub-element
+    return parse_date_time(ele.text + ele[0].text)
 
 ''' takes a link to a story landing page and returns a StoryInfo. '''
 def get_story_info(story_id):
@@ -180,7 +184,7 @@ def get_chapter(url):
             author_id = author_id,
             author_name = author_name,
             choices = choices,
-            created = parse_date(page.xpath(chapter_created_date_xp)[0]),
+            created = parse_date_element(page.xpath(chapter_created_date_xp)[0]),
         )
     except Exception as e:
         print ("Scraping error at " + url)

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,8 +5,8 @@
     <meta charset="utf-8">
 
     <title>Writing.com archive viewer</title>
-    <script src="https://unpkg.com/vue"></script>
-    <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
+    <script src="https://unpkg.com/vue@2"></script>
+    <script src="https://unpkg.com/vue-router@3"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" integrity="sha256-4iQZ6BVL4qNKlQ27TExEhBN1HFPvAvAMbFavKKosSWQ=" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js" integrity="sha256-VeNaFBVDhoX3H+gJ37DpT/nTuZTdjYro9yBruHjVmoQ=" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"


### PR DESCRIPTION
In addition to correcting writing.com schema related issues:

- added args for `--force` and `--full` update flags
  - now there is a way to access these update modes from cmd
- updated archive template to use qualified older versions of vue
  - vue 3 is the default version now, so the vue2-based templates needed to have pinned versions in their cdn links
- bugfixes
  - added missing entries to `requirements.txt`
  - launching run.py with no args resulted in crash
    - now shows warning / reason
  - on update: last_full_update field may exist but be 'null'
    - new check covers non-existence as well as 'null' value