### PR TITLE
New Feature: Collect story keywords

### DIFF
--- a/defs.py
+++ b/defs.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from typing import Dict, Any
 
-class StoryInfo(namedtuple('StoryInfo', ['id', 'author_id', 'author_name', 'description', 'pretty_title', 'brief_description', 'image_url', 'created', 'modified', 'last_full_update'])):
+class StoryInfo(namedtuple('StoryInfo', ['id', 'author_id', 'author_name', 'description', 'pretty_title', 'brief_description', 'image_url', 'created', 'modified', 'last_full_update', 'keywords'])):
     def to_dict(self) -> Dict[str, Any]:
         temp = self._asdict()
         for key in self._fields:

--- a/scraper.py
+++ b/scraper.py
@@ -1,5 +1,5 @@
 from urllib import request, parse
-import json, re, os, mechanicalsoup
+import json, re, os, mechanicalsoup, string
 from datetime import datetime, timezone, timedelta
 from defs import Chapter, StoryInfo, ServerRefusal
 from dateutil import tz
@@ -117,9 +117,11 @@ def get_story_info(story_id):
     if page.text_content().lower().find("list_items/item_type/interactive-stories") == 0:
         return -2
 
-    keywords = page.xpath(story_keywords)
-    if len(keywords):
-        keywords = keywords[0].split()
+    story_kw = page.xpath(story_keywords)
+    if len(story_kw):
+        story_kw = story_kw[0] # collapse xpath result to string
+        story_kw = story_kw.translate(str.maketrans('', '', string.punctuation)) # strip punctuation
+        story_kw = story_kw.split() # make into array of keywords
 
     try:
         story_info = StoryInfo(
@@ -133,7 +135,7 @@ def get_story_info(story_id):
             modified = parse_date_time(page.xpath(story_modified_date)[0] + page.xpath(story_modified_date)[1]),
             image_url = page.xpath(story_image_url_xp)[0],
             last_full_update = None,
-            keywords=keywords
+            keywords=story_kw
         )
 
     except Exception as e:

--- a/scraper.py
+++ b/scraper.py
@@ -41,6 +41,7 @@ story_rating_xp             =   '//div[starts-with(text(),"Rated: ")]/descendant
 story_created_date          =   '//div[starts-with(text(),"Created")]/descendant-or-self::*/text()'
 story_modified_date         =   '//div[starts-with(text(),"Modified")]/descendant-or-self::*/text()'
 story_size                  =   '//div[starts-with(text(),"Size")]/descendant-or-self::*/text()'
+story_keywords              =   '//meta[@name="keywords"]/@content'
 
 recent_elements_xp          =   "//div[@class='mainLineBorderBottom'][@style='relative;padding:10px;']"
 recent_date_xp              =   ".//div[@style='float:right;padding:0px 0px 0px 5px;']/text()"
@@ -116,6 +117,10 @@ def get_story_info(story_id):
     if page.text_content().lower().find("list_items/item_type/interactive-stories") == 0:
         return -2
 
+    keywords = page.xpath(story_keywords)
+    if len(keywords):
+        keywords = keywords[0].split()
+
     try:
         story_info = StoryInfo(
             id = int(page.xpath(story_id_xp)[0]),
@@ -127,7 +132,8 @@ def get_story_info(story_id):
             created = parse_date_time(page.xpath(story_created_date)[0] + page.xpath(story_created_date)[1]),
             modified = parse_date_time(page.xpath(story_modified_date)[0] + page.xpath(story_modified_date)[1]),
             image_url = page.xpath(story_image_url_xp)[0],
-            last_full_update = None
+            last_full_update = None,
+            keywords=keywords
         )
 
     except Exception as e:


### PR DESCRIPTION
This adds support for collecting the keyword tag list for stories.  This change is not reflected in html output.  Rather this is merely additional information stored in the archive JSON.  An attempt is made to clean up tags that include punctuation (commas, semi-colons, etc).

The keywords can be brought in on any operation that rewrites the `info` block.  Examples include: 
* new story archives
* updates that result in a story-info refresh
  * there were new chapters to pull
  * the `--force` argument was used

If keywords refuse to appear and you know they exist, try removing the `last_full_update` member of the `info` block in the archive.  I have found that this can cause flakiness on archives that had errors at some point in their production.