### PR TITLE
Vue-Router 3.6.0 breaks compatibility

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
 
     <title>Writing.com archive viewer</title>
     <script src="https://unpkg.com/vue@2"></script>
-    <script src="https://unpkg.com/vue-router@3"></script>
+    <script src="https://unpkg.com/vue-router@3.5"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" integrity="sha256-4iQZ6BVL4qNKlQ27TExEhBN1HFPvAvAMbFavKKosSWQ=" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js" integrity="sha256-VeNaFBVDhoX3H+gJ37DpT/nTuZTdjYro9yBruHjVmoQ=" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"


### PR DESCRIPTION
pinning to 3.5.x for the time being

All existing archives are affected by this and should be manually edited or regenerated.